### PR TITLE
Hyperlink DOI to preferred resolver

### DIFF
--- a/common/src/main/kotlin/combo/sat/solvers/SolverDefinitions.kt
+++ b/common/src/main/kotlin/combo/sat/solvers/SolverDefinitions.kt
@@ -68,7 +68,7 @@ interface ObjectiveFunction {
     /**
      * For information about possibilities, see:
      * Penalty Function Methods for Constrained Optimization with Genetic Algorithms
-     * http://dx.doi.org/10.3390/mca10010045
+     * https://doi.org/10.3390/mca10010045
      */
     fun penalty(violations: Int) = (violations * violations).toDouble()
 


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected. So, no urgency here, just a suggestion for consistency.

Cheers!