### PR TITLE
Delegate optional absent-value pinning to klause PresenceSpec

### DIFF
--- a/src/jvmMain/kotlin/combo/decisions/DecisionSpace.kt
+++ b/src/jvmMain/kotlin/combo/decisions/DecisionSpace.kt
@@ -69,10 +69,11 @@ abstract class DecisionSpace : SubSpace() {
         PropertyDelegateProvider<DecisionSpace, ReadOnlyProperty<DecisionSpace, BoolContextHandle>> { _, prop ->
             val valueName = ctx.qualify(prop.name)
             val gateName = gateNameFor(valueName)
-            val gateHandle = ctx.root.registerBool(gateName, ctx.activeCondition)
+            val gateHandle = ctx.root.registerPresence(gateName, valueName, ctx.activeCondition)
             val valueHandle = ctx.root.registerBool(
                 valueName,
                 activeCondition = com.eignex.klause.ast.BoolRef(gateName),
+                pin = false,
             )
             val h = BoolContextHandle(valueHandle, isKnownGate = gateHandle)
             _contextBools += h
@@ -87,10 +88,11 @@ abstract class DecisionSpace : SubSpace() {
         PropertyDelegateProvider<DecisionSpace, ReadOnlyProperty<DecisionSpace, IntContextHandle>> { _, prop ->
             val valueName = ctx.qualify(prop.name)
             val gateName = gateNameFor(valueName)
-            val gateHandle = ctx.root.registerBool(gateName, ctx.activeCondition)
+            val gateHandle = ctx.root.registerPresence(gateName, valueName, ctx.activeCondition)
             val valueHandle = ctx.root.registerInt(
                 valueName, min, max,
                 activeCondition = com.eignex.klause.ast.BoolRef(gateName),
+                pin = false,
             )
             val h = IntContextHandle(valueHandle, isKnownGate = gateHandle)
             _contextInts += h

--- a/src/jvmMain/kotlin/combo/decisions/DecisionSpaceDef.kt
+++ b/src/jvmMain/kotlin/combo/decisions/DecisionSpaceDef.kt
@@ -26,6 +26,7 @@ import com.eignex.klause.ast.NominalEq
 import com.eignex.klause.ast.NominalSpec
 import com.eignex.klause.ast.Not
 import com.eignex.klause.ast.Or
+import com.eignex.klause.ast.PresenceSpec
 import com.eignex.klause.ast.SchemaEntry
 import com.eignex.klause.ast.VarSpec
 import com.eignex.klause.compile.CompiledProblem
@@ -139,9 +140,10 @@ data class DecisionSpaceDef(
 
     private fun emitOptional(out: MutableMap<String, SchemaEntry>, qualified: String, spec: VarSpec) {
         val gateName = gateNameFor(qualified)
-        out[gateName] = BoolSpec
+        // The gate is a klause PresenceSpec naming its value var, so klause's own absent-value
+        // pinning fixes the value to its default when the gate is false — no combo `__pin_`.
+        out[gateName] = PresenceSpec(qualified)
         out[qualified] = spec
-        out["__pin_$qualified"] = NamedConstraint(synthesizePin(qualified, spec, gateName))
     }
 }
 
@@ -196,6 +198,10 @@ internal class SchemaLoader : VariableSchema() {
 internal fun synthesizePin(qualifiedName: String, spec: VarSpec, gateName: String): BoolExpr {
     val notGate = Not(BoolRef(gateName))
     return when (spec) {
+        is PresenceSpec ->
+            // A presence marker is a gate, never a pinnable value. The synthesizePin path is
+            // only used for sub-space-gated value vars; gates never reach here.
+            throw UnsupportedOperationException("PresenceSpec '$qualifiedName' is a gate, not a value")
         is BoolSpec -> Implies(notGate, Not(BoolRef(qualifiedName)))
         is IntSpec -> Implies(notGate, IntCompare(IntRef(qualifiedName), IntCmpOp.EQ, IntLit(spec.min)))
         is NominalSpec -> Implies(notGate, NominalEq(qualifiedName, spec.labels[0]))

--- a/src/jvmMain/kotlin/combo/decisions/SubSpaceContext.kt
+++ b/src/jvmMain/kotlin/combo/decisions/SubSpaceContext.kt
@@ -10,6 +10,7 @@ import com.eignex.klause.ast.IntCmpOp
 import com.eignex.klause.ast.IntCompare
 import com.eignex.klause.ast.IntLit
 import com.eignex.klause.ast.IntRef
+import com.eignex.klause.ast.PresenceSpec
 import com.eignex.klause.ast.IntSpec
 import com.eignex.klause.ast.NamedConstraint
 import com.eignex.klause.ast.NominalEq
@@ -104,22 +105,40 @@ internal class RootKlauseSchema : VariableSchema() {
     private val _multiples = LinkedHashMap<String, List<String>>()
     val multiples: Map<String, List<String>> get() = _multiples
 
-    fun registerBool(name: String, activeCondition: BoolExpr?): BoolHandle {
-        add(name, BoolSpec)
+    /**
+     * Register a presence Boolean gating the optional value variable [valueName]. Emitted as
+     * a klause [PresenceSpec] so klause's own absent-value pinning fixes [valueName] to its
+     * default when this gate is false — combo no longer synthesises that pin itself. When
+     * this gate is itself nested under an [activeCondition] (an optional sub-space), it's
+     * still pinned false while the parent is absent.
+     */
+    fun registerPresence(name: String, valueName: String, activeCondition: BoolExpr?): BoolHandle {
+        add(name, PresenceSpec(valueName))
         if (activeCondition != null) {
             _activeConditions[name] = activeCondition
-            // !activeCondition → !var (default = false)
             add("__pin_$name", NamedConstraint(Implies(Not(activeCondition), Not(BoolRef(name)))))
         }
         return BoolHandle(name)
     }
 
-    fun registerInt(name: String, min: Int, max: Int, activeCondition: BoolExpr?): IntHandle {
+    /** [pin] = false records the activation condition (for feature-projection masking) but
+     *  skips the default-pin constraint — used when klause pins the value via [PresenceSpec]. */
+    fun registerBool(name: String, activeCondition: BoolExpr?, pin: Boolean = true): BoolHandle {
+        add(name, BoolSpec)
+        if (activeCondition != null) {
+            _activeConditions[name] = activeCondition
+            // !activeCondition → !var (default = false)
+            if (pin) add("__pin_$name", NamedConstraint(Implies(Not(activeCondition), Not(BoolRef(name)))))
+        }
+        return BoolHandle(name)
+    }
+
+    fun registerInt(name: String, min: Int, max: Int, activeCondition: BoolExpr?, pin: Boolean = true): IntHandle {
         add(name, IntSpec(min, max))
         if (activeCondition != null) {
             _activeConditions[name] = activeCondition
             // !activeCondition → var == min (default = lower bound)
-            add(
+            if (pin) add(
                 "__pin_$name",
                 NamedConstraint(
                     Implies(


### PR DESCRIPTION
Delegates absent-value pinning for optional variables to klause now that klause pins them itself.

combo used to synthesise its own constraint for every optional context variable, of the form "when the gate is off, force the value to its default". klause gained that behaviour natively in PR 58: an optional's presence Boolean is declared as a PresenceSpec that names the value variable it gates, and the compiler pins that value to its default whenever the presence bit is false. This change moves combo onto that mechanism.

For single optional contexts (optionalContextBool and optionalContextInt), combo now registers the isKnown gate as a PresenceSpec naming its value variable, and registers the value with pinning turned off. The gate name is unchanged, so nothing else in combo's compile, decode, assumption-pinning, or feature-projection paths had to move; the activation condition is still recorded for projection masking, only the redundant pin constraint is gone. A new SubSpaceContext.registerPresence does the gate registration, and registerBool and registerInt take a pin flag to skip the constraint while still recording the condition.

Nested optionalDecisionSpace gating stays entirely combo-side. klause pins a single value variable from a single presence bool, whereas combo gates a whole sub-space (with AND-composed conditions across nesting levels) from one bool, which has no klause equivalent. Those variables keep combo's own pin.

synthesizePin gains a PresenceSpec branch. It is only ever called for sub-space-gated value variables, never for gates, so the branch throws; it is also required for the when over VarSpec to stay exhaustive against klause's new variant.

Tested against klause main: the full combo JVM suite passes, including OptionalContextTest (absent age decodes to 0, pinned by klause) and SubSpaceTest (nested audio gating still pinned by combo). Combo builds via includeBuild against the local klause, which now carries PresenceSpec.
