### PR TITLE
chore: update kbuild to 1.2.2 and kumulant to 0.3.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             api("com.eignex:klause")
-            implementation("com.eignex:kumulant:0.3.0")
+            implementation("com.eignex:kumulant:0.3.1")
             compileOnly("org.jetbrains.kotlinx:kotlinx-serialization-core:1.10.0")
         }
         commonTest.dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 
 plugins {
-    id("com.eignex.kmp") version "1.1.5"
+    id("com.eignex.kmp") version "1.2.2"
     kotlin("plugin.serialization") version "2.3.20"
 }
 
@@ -15,7 +15,11 @@ eignexPublish {
 kotlin {
     jvm()
     js(IR) { browser(); nodejs() }
-    wasmJs { browser(); nodejs() }
+    // wasmJs is disabled to match our klause api dependency, which disables it due to a
+    // Kotlin/Wasm 2.3.20 miscompile of its propagation fixpoint loop. kbuild 1.2.2's
+    // partial-resolution checker requires every commonMain dependency to cover all of our
+    // targets, so combo cannot target wasmJs while klause omits it. Re-enable together.
+    // wasmJs { browser(); nodejs() }
     wasmWasi { nodejs() }
     linuxX64(); linuxArm64()
     macosX64(); macosArm64(); mingwX64()


### PR DESCRIPTION
Updates combo's build toolchain to the latest sibling versions.

kbuild (com.eignex.kmp) 1.1.5 to 1.2.2. The new version adds a kmpPartiallyResolvedDependenciesChecker that fails the build unless every commonMain dependency covers all of combo's declared KMP targets. combo's klause api dependency lives in commonMain, and klause disables the wasmJs target due to a Kotlin/Wasm 2.3.20 miscompile of its propagation fixpoint loop. combo therefore cannot target wasmJs while klause omits it, so wasmJs is dropped here with a comment mirroring klause's reasoning. The two should re-enable together once the upstream Kotlin/Wasm regression is fixed.

kumulant 0.3.0 to 0.3.1.

The full combo JVM suite passes against klause main, kumulant 0.3.1, and kbuild 1.2.2.